### PR TITLE
Auto load/reload the project settings on directory changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ These are the defaults.
     file_pattern = './.vimrc.json',
     notify_changed = true,
     notify_unregistered = true,
+    autoload_on_dir_changed = true,
     danger_zone = {
       check_integrity = true
     }
@@ -102,6 +103,8 @@ You can pass this table to the `.setup()` or `.set_config()` functions to tweak 
 * `settings.notify_changed`: Show a message when the settings file has an unregistered change.
 
 * `settings.notify_unregistered`: Show a message if the settings file is not registered.
+
+* `settings.autoload_on_dir_changed`: Automatically load the project settings on directory changed
 
 * `settings.danger_zone.check_integrity`: Enable integrity check of the settings file.
 

--- a/doc/project-settings.txt
+++ b/doc/project-settings.txt
@@ -24,6 +24,7 @@ These are the defaults.
         file_pattern = './.vimrc.json',
         notify_changed = true,
         notify_unregistered = true,
+        autoload_on_dir_changed = true,
         danger_zone = {
           check_integrity = true
         }
@@ -47,6 +48,11 @@ These are the defaults.
 
   settings.notify_unregistered: ~
       Show a message if the settings file is not registered.
+
+                            *project-settings.settings.autoload_on_dir_changed*
+
+  settings.autoload_on_dir_changed: ~
+      Automatically load the project settings on directory changed
 
                        *project-settings.settings.danger_zone.check_integrity*
 

--- a/lua/project-settings/config.lua
+++ b/lua/project-settings/config.lua
@@ -23,6 +23,7 @@ M.defaults = function()
       notify_changed = true,
       file_pattern = './.vimrc.json',
       file_register = vim.fn.stdpath('data') .. '/project-settings.info.json',
+      autoload_on_dir_changed = true,
       danger_zone = {
         check_integrity = true
       }

--- a/lua/project-settings/init.lua
+++ b/lua/project-settings/init.lua
@@ -15,6 +15,15 @@ M.setup = function(opts)
 
   config.setup(opts)
   M.load({verbose = false})
+
+  if config.get().settings.autoload_on_dir_changed == true then
+    local augroup = vim.api.nvim_create_augroup("ProjectSettingsConfig", { clear = true })
+    vim.api.nvim_create_autocmd({"DirChanged"}, {
+      pattern = "*",
+      command = "lua require('project-settings').load({{verbose = false}})",
+      group = augroup
+    })
+  end
 end
 
 M.load = function(opts)
@@ -41,6 +50,7 @@ M.register = function()
 
   -- User **needs** to review the file
   if vim.fn.expand('%:p') ~= current then
+    vim.notify("You need to open " .. current .. " and do ProjectSettingsRegister", vim.log.levels.INFO)
     return
   end
 

--- a/lua/project-settings/init.lua
+++ b/lua/project-settings/init.lua
@@ -20,7 +20,7 @@ M.setup = function(opts)
     local augroup = vim.api.nvim_create_augroup("ProjectSettingsConfig", { clear = true })
     vim.api.nvim_create_autocmd({"DirChanged"}, {
       pattern = "*",
-      command = "lua require('project-settings').load({{verbose = false}})",
+      command = "lua require('project-settings').load({verbose = false})",
       group = augroup
     })
   end


### PR DESCRIPTION
Thanks for this great plugin.

I found a use-case that we often  switch to several projects in the same vim instance, that creates the need to reload the project settings 